### PR TITLE
Fix kflopConsole to properly display all responses until ready is returned

### DIFF
--- a/KMotionX/examples/KFlopConsole/cli.cpp
+++ b/KMotionX/examples/KFlopConsole/cli.cpp
@@ -7,6 +7,7 @@
 
 CKMotionDLL *KM;                // one instance of the interface class
 
+int WaitForReady(int waittime);
 
 int console(const char* msg){
 	printf("CONSOLE> %s",msg );
@@ -39,7 +40,6 @@ int main(int argc, char* argv[])
 			exit(1);
 		} else {
 			printf("Version: %s\n",response);
-
 		}
 	} else {
 		printf("Failed to get lock\n");
@@ -48,30 +48,56 @@ int main(int argc, char* argv[])
 
 	KM->ServiceConsole();
 
-	printf(">Connected.\n");
-	    while(printf("> "), fgets(str, 100, stdin), !feof(stdin)) {
-	        if(strncmp(str,"exit",4) == 0){
+	printf("Connected.\n");
+
+	while(printf(">"), fgets(str, 100, stdin), !feof(stdin)) {
+		if(strncmp(str,"exit",4) == 0){
 	        	break;
 	        }
 	        str[strlen(str) - 1] = '\0';
-	    	if(KM->ServiceConsole()){
+	    	
+
+		if(KM->ServiceConsole()){
 	    		printf(">ServiceConsole Failed\n");
 	    	}
-	    	if(strlen(str) > 1){
-		        if(strncmp(str,"Echo",4) == 0){
-					if(KM->WriteLine(str)){
-						printf(">Command failed\n");
-					}
-		        } else {
-					if(KM->WriteLineReadLine(str,response)){
-						printf(">Command failed\n");
-					} else {
-						printf("< %s\n",response);
 
-					}
-		        }
+	    	if(strlen(str) > 1){
+			if (KM->KMotionLock() == KMOTION_LOCKED)  // see if we can get access
+			{
+				// send command
+				if(KM->WriteLineWithEcho(str)){
+					printf(">Command failed\n");
+					exit(1);
+				}
+
+				// print all responses until we receive "Ready"
+				if (WaitForReady(5000)) {
+					KM->ReleaseToken();
+					printf("Timeout waiting for Ready\n");
+					exit(1);
+				}
+				KM->ReleaseToken();
+			} else {
+				printf("Failed to get lock\n");
+				exit(1);
+			}
 	    	}
-	    }
+	}
 	return 0;
+}
+
+int WaitForReady(int waittime)
+{
+	int timeout;
+	char buf[300];
+
+	do 
+	{
+		timeout = KM->ReadLineTimeOut(buf,waittime);
+		if (!timeout) printf(buf);
+	}
+	while (!timeout && strncmp(buf,"Ready\r\n",7)!=0);
+
+	return timeout;
 }
 


### PR DESCRIPTION
Fix kflopConsole to properly display all responses until ready is returned
